### PR TITLE
8266967: debug.cpp utility find() should print Java Object fields.

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3307,8 +3307,6 @@ nmethod* InstanceKlass::lookup_osr_nmethod(const Method* m, int bci, int comp_le
 // -----------------------------------------------------------------------------------------------------
 // Printing
 
-#ifndef PRODUCT
-
 #define BULLET  " - "
 
 static const char* state_names[] = {
@@ -3459,15 +3457,11 @@ void InstanceKlass::print_on(outputStream* st) const {
   st->cr();
 }
 
-#endif //PRODUCT
-
 void InstanceKlass::print_value_on(outputStream* st) const {
   assert(is_klass(), "must be klass");
   if (Verbose || WizardMode)  access_flags().print_on(st);
   name()->print_value_on(st);
 }
-
-#ifndef PRODUCT
 
 void FieldPrinter::do_field(fieldDescriptor* fd) {
   _st->print(BULLET);
@@ -3525,6 +3519,8 @@ void InstanceKlass::oop_print_on(oop obj, outputStream* st) {
     st->cr();
   }
 }
+
+#ifndef PRODUCT
 
 bool InstanceKlass::verify_itable_index(int i) {
   int method_count = klassItable::method_count_for_interface(this);

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -77,7 +77,6 @@ public:
   virtual void do_field(fieldDescriptor* fd) = 0;
 };
 
-#ifndef PRODUCT
 // Print fields.
 // If "obj" argument to constructor is NULL, prints static fields, otherwise prints non-static fields.
 class FieldPrinter: public FieldClosure {
@@ -87,7 +86,6 @@ class FieldPrinter: public FieldClosure {
    FieldPrinter(outputStream* st, oop obj = NULL) : _obj(obj), _st(st) {}
    void do_field(fieldDescriptor* fd);
 };
-#endif  // !PRODUCT
 
 // Describes where oops are located in instances of this klass.
 class OopMapBlock {
@@ -1263,18 +1261,16 @@ public:
 
  public:
   // Printing
-#ifndef PRODUCT
   void print_on(outputStream* st) const;
-#endif
   void print_value_on(outputStream* st) const;
 
   void oop_print_value_on(oop obj, outputStream* st);
 
-#ifndef PRODUCT
   void oop_print_on      (oop obj, outputStream* st);
 
   void print_dependent_nmethods(bool verbose = false);
   bool is_dependent_nmethod(nmethod* nm);
+#ifndef PRODUCT
   bool verify_itable_index(int index);
 #endif
 

--- a/src/hotspot/share/runtime/fieldDescriptor.cpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.cpp
@@ -129,6 +129,8 @@ void fieldDescriptor::verify() const {
   }
 }
 
+#endif /* PRODUCT */
+
 void fieldDescriptor::print_on(outputStream* st) const {
   access_flags().print_on(st);
   name()->print_value_on(st);
@@ -229,4 +231,3 @@ void fieldDescriptor::print_on_for(outputStream* st, oop obj) {
   }
 }
 
-#endif /* PRODUCT */

--- a/src/hotspot/share/runtime/fieldDescriptor.hpp
+++ b/src/hotspot/share/runtime/fieldDescriptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,8 +113,8 @@ class fieldDescriptor {
 
   // Print
   void print() const;
-  void print_on(outputStream* st) const         PRODUCT_RETURN;
-  void print_on_for(outputStream* st, oop obj)  PRODUCT_RETURN;
+  void print_on(outputStream* st) const;
+  void print_on_for(outputStream* st, oop obj);
   void verify() const                           PRODUCT_RETURN;
 };
 


### PR DESCRIPTION
This change enables debug.cpp's find() utility to print Java Objects with their fields.

find() calls os::print_location, and Java heap objects are printed with instanceKlass oop_print_on.
Removing the ifdef for defining oop_print_on for instanceKlass, and also on methods in FieldPrinter and FieldDescriptor, make this work.


Checking for other uses of os::print_location this might affect:

macroAssembler_x86.cpp has MacroAssembler::print_state32 and MacroAssembler::print_state64
which use os::print_location to print register contents and print words at top of stack.
These will be more verbose, as it already is in non-PRODUCT builds.

vmError uses os::print_location when showing the stack, i.e. this output:

Stack slot to memory mapping:
stack at sp + 0 slots: 0x0000000000000002 is an unknown value
..etc...

...will be more verbose when Java object references are found (for the 8 stack slots it tries to show).


Shenandoah uses os::print_location once, but for non-Java heap objects so nothing changes.




Manual testing on Linux-x64 and Windows: old behaviour shows these two lines only:

"Executing find"
0x00000000ff0a03e0 is an oop: jdk.internal.loader.ClassLoaders$AppClassLoader
{0x00000000ff0a03e0} - klass: 'jdk/internal/loader/ClassLoaders$AppClassLoader'

...then with the change, the full info:

"Executing find"
0x00000000ff0a03e0 is an oop: jdk.internal.loader.ClassLoaders$AppClassLoader
{0x00000000ff0a03e0} - klass: 'jdk/internal/loader/ClassLoaders$AppClassLoader'
 - ---- fields (total size 13 words):
 - private 'defaultAssertionStatus' 'Z' @12  false
 - private final 'parent' 'Ljava/lang/ClassLoader;' @24  a 'jdk/internal/loader/ClassLoaders$PlatformClassLoader'{0x00000000ff0a0a
40} (ff0a0a40)
 - private final 'name' 'Ljava/lang/String;' @28  "app"{0x00000000ff0d0060} (ff0d0060)
 - private final 'unnamedModule' 'Ljava/lang/Module;' @32  a 'java/lang/Module'{0x00000000ff0a0448} (ff0a0448)
...etc...

